### PR TITLE
manually start to-do-list user-service as workaround

### DIFF
--- a/serverless-examples/image-analysis/ui-service/package-lock.json
+++ b/serverless-examples/image-analysis/ui-service/package-lock.json
@@ -1207,9 +1207,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.includes": {

--- a/serverless-examples/to-do-list/.env
+++ b/serverless-examples/to-do-list/.env
@@ -7,8 +7,8 @@ TO_DO_LIST_COGNITO_DOMAIN_BASE=todolist-rwang5688
 
 #>>
 TO_DO_LIST_COGNITO_DOMAIN=todolist-rwang5688.auth.us-west-2.amazoncognito.com
-TO_DO_LIST_USER_POOL_ID=us-west-2_atJtRBF9t
-TO_DO_LIST_USER_POOL_CLIENT_ID=178g6dd8887ssbdem0biqjsltu
-TO_DO_LIST_USER_POOL_ARN=arn:aws:cognito-idp:us-west-2:700702834148:userpool/us-west-2_atJtRBF9t
-TO_DO_LIST_ID_POOL_ID=us-west-2:0208b45b-da81-40fe-923c-55e4378af6a7
+TO_DO_LIST_USER_POOL_ID=us-west-2_2kVYEcS4m
+TO_DO_LIST_USER_POOL_CLIENT_ID=57f3gb6o7jckme3hj5oafuom6i
+TO_DO_LIST_USER_POOL_ARN=arn:aws:cognito-idp:us-west-2:700702834148:userpool/us-west-2_2kVYEcS4m
+TO_DO_LIST_ID_POOL_ID=us-west-2:14ee7a24-7296-4563-a968-ad577912db2e
 #<<

--- a/serverless-examples/to-do-list/deploy.sh
+++ b/serverless-examples/to-do-list/deploy.sh
@@ -26,9 +26,11 @@ function domain () {
 
 
 # create apps and data buckets
-# (waht does frontend deploy do?)
-# create user and identity pools
-SERVICES=(resources frontend user-service)
+# (frontend sls deploy is creating apps bucket again - remove)
+# (user-service sls deploy need to be done bf running this script
+# and we need to manually edit .env to add the various ids and arns)
+# SERVICES=(resources frontend user-service)
+SERVICES=(resources)
 deploy
 
 # create user pool domain


### PR DESCRIPTION
manually start to-do-list user-service as workaround.
The script that extracts the environment variables don't work properly on Windows.